### PR TITLE
Update setup_en.md for pokemon_bw

### DIFF
--- a/worlds/pokemon_bw/docs/setup_en.md
+++ b/worlds/pokemon_bw/docs/setup_en.md
@@ -19,31 +19,50 @@ If you find one, please report it to the #future-game-design thread for this gam
 - A .nds file for the english version of Pokémon Black and White
   - The english versions for USA and Europe are the same
 
-## Joining a MultiWorld Game
+## Optional Software
 
-### Obtain your NDS patch file
+- BizhHawk Client w/ Universal Tracker: 
+  - [BizHawk Client w/ Universal Tracker Version 1.3.0](https://github.com/Rurusachi/Archipelago/releases/tag/BizhawkUT_1.3.0) —
+    There is no Poptracker pack for this apworld at the moment, however there is
+    limited map support for Universal Tracker. **Requires**: Latest compatible version of [Universal Tracker](https://github.com/FarisTheAncient/Archipelago/releases/tag/Tracker_v0.2.14).
+  - Both Universal Tracker and the BizHawk Client w/ Universal Tracker apworlds must be added to your `custom_worlds`
+    folder in your Archipelago install. They should not be in `lib/worlds`.
 
-When you join a multiworld game, you will be asked to provide your YAML file to whoever is hosting. Once that is done,
-the host will provide you with either a link to download your data file, or with a zip file containing everyone's data
-files. Your data file should have a `.apblack` or `.apwhite` extension. 
+## Generating and Patching a Game
 
-Double-click on your `.apblack` or `.apwhite` file to start your client and start the ROM patch process. 
-Once the process is finished, the client and the emulator will be started automatically, 
-if you associated the extension to the client as recommended.
-If the extension isn't associated, select the Archipelago Launcher as the program to open the 
-`.apblack` or `.apwhite` file with.
+1. Add `pokemon_bw.apworld` to your `custom_worlds` folder in your Archipelago install. It should not be in
+   `lib/worlds`.
+2. Create your options file (YAML). You can make one by choosing `Generate Templates`
+   from the Archipelago Launcher. From there, you can edit the `.yaml` in any text editor.
+3. Follow the general Archipelago instructions for [generating a game on your local installation](https://archipelago.gg/tutorial/Archipelago/setup/en#on-your-local-installation).
+   This will generate an output file for you. Your patch file will have the `.apblack` or `.apwhite` file extension 
+   and will be inside the output file.
+4. Open `ArchipelagoLauncher.exe`
+5. Select "Open Patch" on the left side and select your patch file.
+6. If this is your first time patching, you will be prompted to locate your vanilla ROM.
+7. A patched `.nds` file will be created in the same place as the patch file.
+8. On your first time opening a patch with BizHawk Client, you will also be asked to locate `EmuHawk.exe` in your
+   BizHawk install.
 
-### Connect client to emulator
+If you're playing a single-player seed, and you don't care about autotracking or hints, you can stop here, close the
+client, and load the patched ROM in any emulator. However, for multiworlds and other Archipelago features, continue
+below using BizHawk as your emulator.
 
-Once both the client and the emulator are started, you must connect them, if this is not done automatically. Within the 
-emulator click on the "Tools" menu and select "Lua Console". Click the folder button or press Ctrl+O to open a Lua 
-script.
+## Connecting to a Server
 
-Navigate to your Archipelago install folder and open `data/lua/connector_bizhawk_generic.lua`.
+By default, opening a patch file will do steps 1-5 below for you automatically. Even so, keep them in your memory just
+in case you have to close and reopen a window mid-game for some reason.
 
-### Connect to the Multiserver
+1. Pokémon Black & White uses Archipelago's BizHawk Client. If the client isn't still open from when you patched your game,
+you can re-open it from the launcher.
+2. Ensure EmuHawk is running the patched ROM.
+3. In EmuHawk, go to `Tools > Lua Console`. This window must stay open while playing.
+4. In the Lua Console window, go to `Script > Open Script…`.
+5. Navigate to your Archipelago install folder and open `data/lua/connector_bizhawk_generic.lua`.
+6. The emulator and client will eventually connect to each other. The BizHawk Client window should indicate that it
+connected and recognized Pokémon Black & White.
+7. To connect the client to the server, enter your room's address and port (e.g. `archipelago.gg:38281`) into the
+top text field of the client and click Connect. An alternative way to connect is typing `/connect <address>:<port> [password]` into the bottom text field and then typing your slot name (if prompted).
 
-To connect the client to the multiserver simply put `<address>:<port>` on the textfield on top and 
-press enter or `Connect`. 
-An alternative way to connect is typing `/connect <address>:<port> [password]` into the bottom text field and then 
-typing your slot name (if prompted).
+You should now be able to receive and send items. You'll need to do these steps every time you want to reconnect. It is
+perfectly safe to make progress offline; everything will re-sync when you reconnect.

--- a/worlds/pokemon_bw/docs/setup_en.md
+++ b/worlds/pokemon_bw/docs/setup_en.md
@@ -9,7 +9,7 @@ If you find one, please report it to the #future-game-design thread for this gam
 ## Required Software
 
 - BizHawk: [Bizhawk Releases from TASVideos](https://tasvideos.org/BizHawk/ReleaseHistory)
-  - Version 2.10 is recommended
+  - Version 2.10+ is recommended
   - **Important**: Upon opening the emulator for the first time, go to `Config > Customize... > Advanced` 
     and **disable** `AutoSaveRam`. Else, save data might not be properly saved.
   - Detailed installation instructions for BizHawk can be found at the above link.
@@ -22,11 +22,9 @@ If you find one, please report it to the #future-game-design thread for this gam
 ## Optional Software
 
 - BizhHawk Client w/ Universal Tracker: 
-  - [BizHawk Client w/ Universal Tracker Version 1.3.0](https://github.com/Rurusachi/Archipelago/releases/tag/BizhawkUT_1.3.0) —
-    There is no Poptracker pack for this apworld at the moment, however there is
-    limited map support for Universal Tracker. **Requires**: Latest compatible version of [Universal Tracker](https://github.com/FarisTheAncient/Archipelago/releases/tag/Tracker_v0.2.14).
-  - Both Universal Tracker and the BizHawk Client w/ Universal Tracker apworlds must be added to your `custom_worlds`
-    folder in your Archipelago install. They should not be in `lib/worlds`.
+  - BizHawk Client w/ Universal Tracker — There is no Poptracker pack for this apworld at the moment, however there is limited map support for Universal Tracker. **Requires**: Latest compatible version of Universal Tracker.
+  - Both Universal Tracker and the BizHawk Client w/ Universal Tracker apworlds must be added to your `custom_worlds` folder in your Archipelago install. They should not be in `lib/worlds`.
+  - Visit the `Universal Tracker` channel in the Archipelago Discord server for links to both apworld releases.
 
 ## Generating and Patching a Game
 


### PR DESCRIPTION
Reworked the setup guide for specificity.

Pros: 

1. Added optional software section for the BizHawk UT client and limited map tracking.
2. Added a guide for generating a template for a custom_world.
 - Reduce the `&template` spam in the channel.
4. Expanded the directions on how to connect to an AP server

Cons:

1. ~~I need to change the info for the BizHawk UT client to have the user go to that channel in the AP discord regarding setup.~~
 - The UT apworld is in Faris' github repository on the same branch as all of their other AP related releases, so linking to a `/latest/` will not work well.
 ~~- Will check to see if the BHw/UT apworld is on its own repository.~~